### PR TITLE
man ドキュメントの「使用法」を修正

### DIFF
--- a/mendex.1
+++ b/mendex.1
@@ -4,7 +4,7 @@
 .SH NAME
 mendex \- Japanese index processor
 .SH SYNOPSIS
-\fBmendex\fR [-ilqrcgEJSU] [\fB-s\fI sty\fR] [\fB-d\fI dic\fR] [\fB-o\fI ind\fR] [\fB-d\fI dic\fR] [\fB-t\fI log\fR] [\fB-p\fI no\fR] [\fB-I\fI enc\fR] [\fB--\fR] [\fI idx0 idx1 idx2 ...\fR]
+\fBmendex\fR [-ilqrcgfEJSU] [\fB-s\fI sty\fR] [\fB-d\fI dic\fR] [\fB-o\fI ind\fR] [\fB-t\fI log\fR] [\fB-p\fI no\fR] [\fB-I\fI enc\fR] [\fB--\fR] [\fI idx0 idx1 idx2 ...\fR]
 .SH DESCRIPTION
 .PP
 The program \fImendex\fR is a general purpose hierarchical index generator;

--- a/mendex.1.ja
+++ b/mendex.1.ja
@@ -4,7 +4,7 @@
 .SH 名称
 mendex \- 索引整形ツール
 .SH 使用法
-\fBmendex\fR [-ilqrcgEJSU] [\fB-s\fI sty\fR] [\fB-d\fI dic\fR] [\fB-o\fI ind\fR] [\fB-d\fI dic\fR] [\fB-t\fI log\fR] [\fB-p\fI no\fR] [\fB-I\fI enc\fR] [\fB--\fR] [\fI idx0 idx1 idx2 ...\fR]
+\fBmendex\fR [-ilqrcgfEJSU] [\fB-s\fI sty\fR] [\fB-d\fI dic\fR] [\fB-o\fI ind\fR] [\fB-t\fI log\fR] [\fB-p\fI no\fR] [\fB-I\fI enc\fR] [\fB--\fR] [\fI idx0 idx1 idx2 ...\fR]
 .SH 解説
 .PP
 \fImendex\fR は文書の索引を作成するツールです。 LaTeX により抽出された索引リストファイル(\fI.idx\fR)を並べ替え、実際の索引のソースファイルの形に整形します。 \fImakeindex\fR と互換性があり、さらに「読み」の扱いの手間を減らすように特殊化されています。


### PR DESCRIPTION
既存の man ドキュメントには

- `-f` の存在が抜けている
- `[-d dic]` が2回登場していて冗長

という問題があったので修正しました．